### PR TITLE
Remove logging URL during fetch()

### DIFF
--- a/src/main/java/com/crazzyghost/alphavantage/timeseries/TimeSeries.java
+++ b/src/main/java/com/crazzyghost/alphavantage/timeseries/TimeSeries.java
@@ -76,7 +76,7 @@ public class TimeSeries{
                 .url(Config.BASE_URL + UrlExtractor.extract(this.request) + config.getKey())
                 .build();
 
-        System.out.println(Config.BASE_URL + UrlExtractor.extract(this.request) + "***");
+    //    System.out.println(Config.BASE_URL + UrlExtractor.extract(this.request) + "***");
 
         //make the call
 //        System.out.println("Fetching Response ...");


### PR DESCRIPTION
The URL of each request is logged when fetch() method is invoked. This might want to be removed in case fetch() method is used constantly, in order to avoid spamming the log.